### PR TITLE
chore: fix unmet peer warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "version": "npm run changelog && git add CHANGELOG.md"
   },
   "peerDependencies": {
-    "tailwindcss": "^3.0.0 || ^v4.0.0"
+    "tailwindcss": "^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "version": "npm run changelog && git add CHANGELOG.md"
   },
   "peerDependencies": {
-    "tailwindcss": "^3.0.0 || v4.0.0"
+    "tailwindcss": "^3.0.0 || ^v4.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",


### PR DESCRIPTION
 WARN  Issues with peer dependencies found
.
└─┬ tailwind-plugin-typed 1.1.0
  └── ✕ unmet peer tailwindcss@"^3.0.0 || v4.0.0": found 4.0.9